### PR TITLE
Quicksand Fixes

### DIFF
--- a/FairAI/Patches/QuickSandPatch.cs
+++ b/FairAI/Patches/QuickSandPatch.cs
@@ -100,11 +100,8 @@ namespace FairAI.Patches
 
                         if (upgradeStats.Length > 0)
                         {
-                            // Now you can access instance fields or methods from it:
-                            FieldInfo upgradeLevelsField = upgradeBusType.GetField("upgradeLevels", BindingFlags.Instance | BindingFlags.NonPublic);
-                            Dictionary<string, int> upgradeLevels = (Dictionary<string, int>)upgradeLevelsField.GetValue(upgradeBusInstance);
-                            int rubberBootsLvl = upgradeLevels["Rubber Boots"];
-                            Plugin.logger.LogInfo("Rubber Boots Tier: " + rubberBootsLvl);
+                            Plugin.logger.LogInfo("Rubber Boots Tier: " + upgradeStats[0]);
+
                             // Call the static methods
                             float adjustedHinderance = (float)reduceMethod.Invoke(null, [hinderance]);
 
@@ -113,6 +110,8 @@ namespace FairAI.Patches
 
                             // Reset or clear effect
                             clearMethod.Invoke(null, [(int)adjustedHinderance]);
+
+                            // currentUpgrade == maxUpgrade
                             if (upgradeStats[0] == upgradeStats[1])
                             {
                                 playerScript.isMovementHindered = 0;


### PR DESCRIPTION
These patches fix some bugs in how hinderedMultiplier is applied in StopSinkingLocalPlayerPatch.

This might fix #27 since OnTriggerStayPatch appeared to be double-applying a hinderance, and some old debug code was causing a NullReferenceException that would've prevented the rubberBoots effects from applying fully.